### PR TITLE
fix: Enabling the trigger mechanism for strava

### DIFF
--- a/tapiriik/services/Strava/strava.py
+++ b/tapiriik/services/Strava/strava.py
@@ -29,7 +29,7 @@ class StravaService(ServiceBase):
     UserProfileURL = "http://www.strava.com/athletes/{0}"
     UserActivityURL = "http://app.strava.com/activities/{1}"
     AuthenticationNoFrame = True  # They don't prevent the iframe, it just looks really ugly.
-    PartialSyncRequiresTrigger = False
+    PartialSyncRequiresTrigger = True
     # PartialSyncTriggerRequiresSubscription = True
     LastUpload = None
 

--- a/tapiriik/services/service_record.py
+++ b/tapiriik/services/service_record.py
@@ -23,6 +23,8 @@ class ServiceRecord:
     ExcludedActivities = {}
     Config = {}
     PartialSyncTriggerSubscribed = False
+    # If absent, the trigger handling will not work
+    TriggerPartialSync = False
 
     @property
     def Service(self):

--- a/tapiriik/web/views/sync.py
+++ b/tapiriik/web/views/sync.py
@@ -99,6 +99,9 @@ def sync_clear_errorgroup(req, service, group):
 def sync_trigger_partial_sync_callback(req, service):
     svc = Service.FromID(service)
     if req.method == "POST":
+        # We import the trigger handler mostly for strava rate limitations
+        from sync_remote_triggers import trigger_remote
+
         # if whe're using decathlon services, force resync
         # Get users ids list, depending of services
         response = svc.ExternalIDsForPartialSyncTrigger(req)
@@ -107,6 +110,8 @@ def sync_trigger_partial_sync_callback(req, service):
         # Get users _id list from external ID
         users_to_sync = _sync.getUsersIDFromExternalId(response, service)
 
+        # We launch the hadler to set the trigger to True in the database
+        trigger_remote(service, response)
 
         for user in users_to_sync:
             # verify if it is an user


### PR DESCRIPTION
- Re-including the already existing sync_remote_trigger.py to the callback handler
- Strava service's "PartialSyncRequiresTrigger" flag set to "True"
- Addded the "TriggerPartialSync" flag to service_record.py (Avoiding raising exceptions for its absence)