### PR TITLE
feat: log colorization

### DIFF
--- a/colog.py
+++ b/colog.py
@@ -1,0 +1,50 @@
+BLACK_COLOR="\u001b[30m"
+def black(stringToColor):
+	return BLACK_COLOR + str(stringToColor) + RESET_COLOR
+
+RED_COLOR="\u001b[31m"
+def red(stringToColor):
+	return RED_COLOR + str(stringToColor) + RESET_COLOR
+
+GREEN_COLOR="\u001b[32m"
+def green(stringToColor):
+	return GREEN_COLOR + str(stringToColor) + RESET_COLOR
+
+YELLOW_COLOR="\u001b[33m"
+def yellow(stringToColor):
+	return YELLOW_COLOR + str(stringToColor) + RESET_COLOR
+
+BLUE_COLOR="\u001b[34m"
+def blue(stringToColor):
+	return BLUE_COLOR + str(stringToColor) + RESET_COLOR
+
+MAGENTA_COLOR="\u001b[35m"
+def magenta(stringToColor):
+	return MAGENTA_COLOR + str(stringToColor) + RESET_COLOR
+
+CYAN_COLOR="\u001b[36m"
+def cyan(stringToColor):
+	return CYAN_COLOR + str(stringToColor) + RESET_COLOR
+
+WHITE_COLOR="\u001b[37m"
+def white(stringToColor):
+	return WHITE_COLOR + str(stringToColor) + RESET_COLOR
+
+RESET_COLOR="\u001b[0m"
+def reset(stringToColor):
+	return RESET_COLOR + str(stringToColor) + RESET_COLOR
+
+
+
+# If you want to add other colors (i.e. the "bright ones")
+# Go there : https://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html
+
+# Copy paste the codes you want like this :
+# Black: \u001b[30m
+# Red: \u001b[31m
+
+# Then research for this regex :
+# ([A-Za-z]*): (\\u001b\[\d*m)
+
+# And replace by this
+# \U$1_COLOR="$2"\ndef \L$1(stringToColor):\n\treturn \U$1_COLOR + str(stringToColor) + RESET_COLOR\n

--- a/tapiriik/settings.py
+++ b/tapiriik/settings.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.utils.translation import ugettext_lazy as _
 import logging
 import logging.handlers
+import colog
 import io
 
 # Django settings for tapiriik project.
@@ -59,6 +60,11 @@ logging_console_handler = logging.StreamHandler(io.TextIOWrapper(sys.stdout.buff
 logging_console_handler.setLevel(logging.INFO)
 logging_console_handler.setFormatter(logging.Formatter('%(asctime)s|%(levelname)s\t|%(message)s |%(funcName)s in %(filename)s:%(lineno)d','%Y-%m-%d %H:%M:%S'))
 _GLOBAL_LOGGER.addHandler(logging_console_handler)
+
+# Adding colog as a setting var (like _GLOBAL_LOGGER)
+# Quite usefull because pretty all files tend to import those settings mostly for the logger.
+COLOG = colog
+_GLOBAL_LOGGER.info(COLOG.yellow("Initializing log colorization"))
 
 SITE_ID = 1
 


### PR DESCRIPTION
Creation of a string colorizer using ASCI escape chars.
This is meant to be use within the actual _GLOBAL_LOGGER.
It is included in the settings of the project (next to the global logger) to minimize the impact in all the files that want to use it.