### PR TITLE
fix: Commented the deffered services call

### DIFF
--- a/tapiriik/sync/sync.py
+++ b/tapiriik/sync/sync.py
@@ -1047,7 +1047,8 @@ class SynchronizationTask:
 
                     if not exhaustive and conn.Service.PartialSyncRequiresTrigger and "TriggerPartialSync" not in conn.__dict__ and not conn.Service.ShouldForcePartialSyncTrigger(conn):
                         self._global_logger.info("Service %s has not been triggered" % conn.Service.ID)
-                        self._deferredServices.append(conn._id)
+                        # Commented it over consume API calls without any visible benefits
+                        # self._deferredServices.append(conn._id)
                         continue
 
                     if not conn.Service.SuppliesActivities:


### PR DESCRIPTION
When it is activated, the connections that has not been triggered have to give a listing of the activities for no visible reason.
This will reduce the API call consumption by 1 for each users by sync