### PR TITLE
fix: Allowing user to disconnect service when rate limit are reached

### DIFF
--- a/tapiriik/services/Strava/strava.py
+++ b/tapiriik/services/Strava/strava.py
@@ -153,7 +153,10 @@ class StravaService(ServiceBase):
     def RevokeAuthorization(self, serviceRecord):
         resp = self._requestWithAuth(lambda session: session.post("https://www.strava.com/oauth/deauthorize"), serviceRecord)
         if resp.status_code != 204 and resp.status_code != 200:
-            raise APIException("Unable to deauthorize Strava auth token, status " + str(resp.status_code) + " resp " + resp.text)
+            if resp.status_code == 429:
+                logger.warning("Rate limit exeception %s - %s" % (resp.status_code, resp.text))
+            else:
+                raise APIException("Unable to deauthorize Strava auth token, status " + str(resp.status_code) + " resp " + resp.text)
 
     def DownloadActivityList(self, svcRecord, exhaustive=False):
         activities = []


### PR DESCRIPTION
Not throwing an exception but the event is logged with a warning.
Other unwanted http code still raise exception.