### PR TITLE
fix: Laps no longer have the same stats as the activity if there is more than one

### DIFF
--- a/tapiriik/services/Decathlon/decathlon.py
+++ b/tapiriik/services/Decathlon/decathlon.py
@@ -474,7 +474,8 @@ class DecathlonService(ServiceBase):
 
                 if "LAP" in rd :
                     #build the lap
-                    lap = Lap(stats = activity.Stats, startTime = startTimeLap, endTime = formatedDate) 
+                    # No statistic added because we don't have a way to effectively get them
+                    lap = Lap(startTime = startTimeLap, endTime = formatedDate)
                     lap.Waypoints = lapWaypoints
                     activity.Laps.append(lap)
                     # re init a new lap
@@ -483,7 +484,7 @@ class DecathlonService(ServiceBase):
 
             #build last lap
             if len(lapWaypoints)>0 :
-                lap = Lap(stats = activity.Stats, startTime = startTimeLap, endTime = formatedDate) 
+                lap = Lap(startTime = startTimeLap, endTime = formatedDate) 
                 lap.Waypoints = lapWaypoints
                 activity.Laps.append(lap)
   


### PR DESCRIPTION
As the dominant recipient (decathlon coach apart) is Strava.
I decided to simply remove the stat from laps to let Strava calculate them by itself.