### PR TITLE
refactor: deleted old celery queue management related files

### DIFF
--- a/tapiriik/messagequeue/__init__.py
+++ b/tapiriik/messagequeue/__init__.py
@@ -1,4 +1,0 @@
-from kombu import Connection
-from tapiriik.settings import RABBITMQ_BROKER_URL
-mq = Connection(RABBITMQ_BROKER_URL, transport_options={'confirm_publish': True})
-mq.connect()


### PR DESCRIPTION
With this we can avoid crashing the unit tests.