### PR TITLE
test: failling test settings adjustment

### DIFF
--- a/tapiriik/settings.py
+++ b/tapiriik/settings.py
@@ -262,8 +262,6 @@ WEBPACK_LOADER = {
         }
 }
 
-TEST_RUNNER = 'tapiriik.testing.MongoDBTestRunner'
-
 MONGO_HOST_API = "localhost"
 MONGO_REPLICA_SET = None
 MONGO_CLIENT_OPTIONS = {}

--- a/tapiriik/settings.py
+++ b/tapiriik/settings.py
@@ -262,6 +262,12 @@ WEBPACK_LOADER = {
         }
 }
 
+DATABASES = {
+    "default": { 
+        "ENGINE": "django.db.backends.sqlite3"
+    }
+}
+
 MONGO_HOST_API = "localhost"
 MONGO_REPLICA_SET = None
 MONGO_CLIENT_OPTIONS = {}


### PR DESCRIPTION
Deleted the TEST_RUNNER var from the setting which pointed to an inexistent code. So it made the tests crash.

Also added the required DATABASE var into the setting file.
It seems that this db is meant to store some tests results and it is deleted after all tests result are reported back to the tester.