### PR TITLE
fix: Answering the expected value to Coros webhook to avoid retries

### DIFF
--- a/tapiriik/web/views/sync.py
+++ b/tapiriik/web/views/sync.py
@@ -119,10 +119,7 @@ def sync_trigger_partial_sync_callback(req, service):
             # verify if it is an user
             if "_id" not in user:
                 if svc.ID == "coros":
-                    return JsonResponse({
-                        "message":"not authorized",
-                        "result":"0002"
-                    })  
+                    continue  
                 return HttpResponse(status=403)    
             # For each users, if we can sync now
             if "LastSynchronization" in user and user["LastSynchronization"] is not None and datetime.utcnow() - \

--- a/tapiriik/web/views/sync.py
+++ b/tapiriik/web/views/sync.py
@@ -1,5 +1,6 @@
 import json
 from django.http import HttpResponse
+from django.http.response import JsonResponse
 from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_exempt
 from tapiriik.auth import User
@@ -117,6 +118,11 @@ def sync_trigger_partial_sync_callback(req, service):
         for user in users_to_sync:
             # verify if it is an user
             if "_id" not in user:
+                if svc.ID == "coros":
+                    return JsonResponse({
+                        "message":"not authorized",
+                        "result":"0002"
+                    })  
                 return HttpResponse(status=403)    
             # For each users, if we can sync now
             if "LastSynchronization" in user and user["LastSynchronization"] is not None and datetime.utcnow() - \
@@ -127,6 +133,11 @@ def sync_trigger_partial_sync_callback(req, service):
             # Force immadiate sync
             _sync.ScheduleImmediateSync(user, exhaustive)
 
+        if svc.ID == "coros":
+            return JsonResponse({
+                "message":"ok",
+                "result":"0000"
+            })  
         return HttpResponse(status=svc.PartialSyncTriggerStatusCode)
 
     elif req.method == "GET":	


### PR DESCRIPTION
Sending some Json back to say if it's a success or not.