### PR TITLE
Fix: doubled run cadence

### DIFF
--- a/tapiriik/services/Decathlon/decathlon.py
+++ b/tapiriik/services/Decathlon/decathlon.py
@@ -468,7 +468,8 @@ class DecathlonService(ServiceBase):
                     wp.Cadence = rd['CADENCE']
 
                 if 'R_CADENCE' in rd :
-                     wp.RunCadence = rd['R_CADENCE']
+                    # Here we want the RunCadence to be a batch of 1 left and 1 right step (As the fit ask to)
+                     wp.RunCadence = rd['R_CADENCE']/2
 
                 if 'POWER' in rd :
                     wp.Power = rd['POWER']

--- a/tapiriik/services/Decathlon/decathlon.py
+++ b/tapiriik/services/Decathlon/decathlon.py
@@ -562,8 +562,10 @@ class DecathlonService(ServiceBase):
                         oneMeasureLocation[self._unitMap["kcal"]] = int(wp.Calories)
                     if wp.Distance is not None:
                         oneMeasureLocation[self._unitMap["distance"]] = int(wp.Distance)
+                    if wp.RunCadence is not None:
+                        # We have the number of left and right steps couple but Decathlon stores the number of unique steps so we have to do *2
+                        oneMeasureLocation[self._unitMap["cadence"]] = int(wp.RunCadence*2)
                     if wp.Cadence is not None:
-                        oneMeasureLocation[self._unitMap["cadence"]] = int(wp.Cadence)
                         oneMeasureLocation[self._unitMap["rpm"]] = int(wp.Cadence)
                     dataStream[elapsedTime] = oneMeasureLocation
             if addLap and oneMeasureLocation is not None:

--- a/tapiriik/services/fit.py
+++ b/tapiriik/services/fit.py
@@ -928,7 +928,8 @@ class FITIO:
 				if wp.HR is not None:
 					rec_contents.update({"heart_rate": wp.HR})
 				if wp.RunCadence is not None:
-					rec_contents.update({"cadence": (wp.RunCadence/2 if (act.ServiceData != None and act.ServiceData.get("Origin") == "decathlon") else wp.RunCadence)})
+					# Here we asume we already have the Run_Cadence as batch of 1 left and 1 right step (As the fit ask to)
+					rec_contents.update({"cadence": wp.RunCadence})
 				if wp.Cadence is not None:
 					rec_contents.update({"cadence": wp.Cadence})
 				if wp.Power is not None:


### PR DESCRIPTION
Now the "pivot" run cadence is the number of left and right steps couple instead of number of left plus right steps per minutes.

So the run cadence from decathlon is devided by two and the run cadence from the hub to decathlon is doubled.